### PR TITLE
+ Update doc - fix mistype

### DIFF
--- a/doc/en/exploitation/index.rst
+++ b/doc/en/exploitation/index.rst
@@ -58,11 +58,10 @@ In case you have many VirtualCenters, the configuration is (note the use of "," 
                         'default' => {'url' => 'https://vcenter/sdk',
                                      'username' => 'test@test.fr',
                                      'password' => 'xxxx'},
-                        },
                         'other' => {'url' => 'https://other_vcenter/sdk',
                                      'username' => 'test@test.fr',
                                      'password' => 'xxxx'},
-                        }
+                        },
     );
 
 'other' and 'default' are containers name.


### PR DESCRIPTION
Fix error in config file syntax when defining multiple vCenter