### PR TITLE
Adding non standard UOM to perfdata breaks nagios/icinga graph

### DIFF
--- a/centreon/vmware/cmdcpuhost.pm
+++ b/centreon/vmware/cmdcpuhost.pm
@@ -136,7 +136,7 @@ sub run {
                                                  warning => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                                  critical => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'critical'),
                                                  min => 0, max => 100);
-        $self->{manager}->{output}->perfdata_add(label => 'cpu_total_MHz' . $extra_label, unit => 'MHz',
+        $self->{manager}->{output}->perfdata_add(label => 'cpu_total_MHz' . $extra_label, unit => '',
                                                  value => $total_cpu_mhz_average,
                                                  min => 0, max => $entity_view->{'summary.hardware.numCpuCores'} * $entity_view->{'summary.hardware.cpuMhz'});
 

--- a/centreon/vmware/cmdcpuvm.pm
+++ b/centreon/vmware/cmdcpuvm.pm
@@ -144,7 +144,7 @@ sub run {
         foreach my $entry (({ value => $total_cpu_average, label => 'usage', output => 'Total Average CPU usage %s %%',
                               perf_label => 'cpu_total', perf_min => 0, perf_max => 100, perf_unit => '%' }, 
                             { value => $total_cpu_mhz_average, label => 'usagemhz', output => 'Total Average CPU %s Mhz',
-                              perf_label => 'cpu_total_MHz', perf_min => 0, perf_unit => 'MHz'}, 
+                              perf_label => 'cpu_total_MHz', perf_min => 0, perf_unit => ''}, 
                             { value => $total_cpu_ready, label => 'ready', output => 'CPU ready %s %%',
                               perf_label => 'cpu_ready', perf_min => 0, perf_unit => '%' })) {
             my $exit = $self->{manager}->{perfdata}->threshold_check(value => $entry->{value}, threshold => [ { label => 'critical_' . $entry->{label}, exit_litteral => 'critical' }, { label => 'warning_' . $entry->{label}, exit_litteral => 'warning' } ]);
@@ -191,7 +191,7 @@ sub run {
             my ($counter_id, $instance) = split /:/, $id;
             next if ($self->{connector}->{perfcounter_cache}->{'cpu.usagemhz.average'}->{key} != $counter_id);
             if ($instance ne "") {
-                $self->{manager}->{output}->perfdata_add(label => 'cpu_' . $instance . '_MHz' . $extra_label, unit => 'MHz',
+                $self->{manager}->{output}->perfdata_add(label => 'cpu_' . $instance . '_MHz' . $extra_label, unit => '',
                                                          value => centreon::vmware::common::simplify_number(centreon::vmware::common::convert_number($values->{$entity_value}->{$id})),
                                                          min => 0);
             }

--- a/centreon/vmware/cmddatastoreio.pm
+++ b/centreon/vmware/cmddatastoreio.pm
@@ -136,12 +136,12 @@ sub run {
         
         my $extra_label = '';
         $extra_label = '_' . $entity_view->{'summary.name'} if ($multiple == 1);
-        $self->{manager}->{output}->perfdata_add(label => 'read_rate' . $extra_label, unit => 'B/s',
+        $self->{manager}->{output}->perfdata_add(label => 'read_rate' . $extra_label, unit => 'B',
                                                  value => $read_counter,
                                                  warning => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                                  critical => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'critical'),
                                                  min => 0);
-        $self->{manager}->{output}->perfdata_add(label => 'write_rate' . $extra_label, unit => 'B/s',
+        $self->{manager}->{output}->perfdata_add(label => 'write_rate' . $extra_label, unit => 'B',
                                                  value => $write_counter,
                                                  warning => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                                  critical => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'critical'),

--- a/centreon/vmware/cmddatastoreiops.pm
+++ b/centreon/vmware/cmddatastoreiops.pm
@@ -229,12 +229,12 @@ sub run {
         
         my $extra_label = '';
         $extra_label = '_' . $_ if ($multiple == 1);
-        $self->{manager}->{output}->perfdata_add(label => 'riops' . $extra_label, unit => 'iops',
+        $self->{manager}->{output}->perfdata_add(label => 'riops' . $extra_label, unit => '',
                                                  value => $total_read_counter,
                                                  warning => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                                  critical => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'critical'),
                                                  min => 0);
-        $self->{manager}->{output}->perfdata_add(label => 'wiops' . $extra_label, unit => 'iops',
+        $self->{manager}->{output}->perfdata_add(label => 'wiops' . $extra_label, unit => '',
                                                  value => $total_write_counter,
                                                  warning => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                                  critical => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'critical'),

--- a/centreon/vmware/cmddatastorevm.pm
+++ b/centreon/vmware/cmddatastorevm.pm
@@ -224,12 +224,12 @@ sub run {
                                                    $prefix_msg, $_, $write_counter));
             }
             
-            $self->{manager}->{output}->perfdata_add(label => 'riops' . $extra_label . '_' . $_, unit => 'iops',
+            $self->{manager}->{output}->perfdata_add(label => 'riops' . $extra_label . '_' . $_, unit => '',
                                                      value => $read_counter,
                                                      warning => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                                      critical => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'critical'),
                                                      min => 0);
-            $self->{manager}->{output}->perfdata_add(label => 'wiops' . $extra_label . '_' . $_, unit => 'iops',
+            $self->{manager}->{output}->perfdata_add(label => 'wiops' . $extra_label . '_' . $_, unit => '',
                                                      value => $write_counter,
                                                      warning => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                                      critical => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'critical'),

--- a/centreon/vmware/cmdnethost.pm
+++ b/centreon/vmware/cmdnethost.pm
@@ -246,12 +246,12 @@ sub run {
             my $extra_label = '';
             $extra_label .= '_' . $_ if ($number_nic > 1);
             $extra_label .= '_' . $entity_view->{name} if ($multiple == 1);
-            $self->{manager}->{output}->perfdata_add(label => 'traffic_in' . $extra_label, unit => 'b/s',
+            $self->{manager}->{output}->perfdata_add(label => 'traffic_in' . $extra_label, unit => 'B',
                                           value => sprintf("%.2f", $traffic_in),
                                           warning => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'warning-in', total => $interface_speed),
                                           critical => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'critical-in', total => $interface_speed),
                                           min => 0, max => $interface_speed);
-            $self->{manager}->{output}->perfdata_add(label => 'traffic_out' . $extra_label, unit => 'b/s',
+            $self->{manager}->{output}->perfdata_add(label => 'traffic_out' . $extra_label, unit => 'B',
                                           value => sprintf("%.2f", $traffic_out),
                                           warning => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'warning-out', total => $interface_speed),
                                           critical => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'critical-out', total => $interface_speed),

--- a/centreon/vmware/cmdswaphost.pm
+++ b/centreon/vmware/cmdswaphost.pm
@@ -137,12 +137,12 @@ sub run {
         
         my $extra_label = '';
         $extra_label = '_' . $entity_view->{name} if ($multiple == 1);
-        $self->{manager}->{output}->perfdata_add(label => 'swap_in' . $extra_label, unit => 'B/s',
+        $self->{manager}->{output}->perfdata_add(label => 'swap_in' . $extra_label, unit => 'B',
                                                  value => $swap_in,
                                                  warning => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                                  critical => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'critical'),
                                                  min => 0);
-        $self->{manager}->{output}->perfdata_add(label => 'swap_out' . $extra_label, unit => 'B/s',
+        $self->{manager}->{output}->perfdata_add(label => 'swap_out' . $extra_label, unit => 'B',
                                                  value => $swap_out,
                                                  warning => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                                  critical => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'critical'),

--- a/centreon/vmware/cmdswapvm.pm
+++ b/centreon/vmware/cmdswapvm.pm
@@ -160,12 +160,12 @@ sub run {
         
         my $extra_label = '';
         $extra_label = '_' . $entity_view->{name} if ($multiple == 1);
-        $self->{manager}->{output}->perfdata_add(label => 'swap_in' . $extra_label, unit => 'B/s',
+        $self->{manager}->{output}->perfdata_add(label => 'swap_in' . $extra_label, unit => 'B',
                                                  value => $swap_in,
                                                  warning => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                                  critical => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'critical'),
                                                  min => 0);
-        $self->{manager}->{output}->perfdata_add(label => 'swap_out' . $extra_label, unit => 'B/s',
+        $self->{manager}->{output}->perfdata_add(label => 'swap_out' . $extra_label, unit => 'B',
                                                  value => $swap_out,
                                                  warning => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                                  critical => $self->{manager}->{perfdata}->get_perfdata_for_output(label => 'critical'),


### PR DESCRIPTION
As stated in guidelines https://nagios-plugins.org/doc/guidelines.html the unit of measurement must be:
```
UOM (unit of measurement) is one of:

    no unit specified - assume a number (int or float) of things (eg, users, processes, load averages)
    s - seconds (also us, ms)
    % - percentage
    B - bytes (also KB, MB, TB)
    c - a continous counter (such as bytes transmitted on an interface)
```
Using other UOM breaks nagios/icinga2/influxdb/thruk and many more tools.