### PR TITLE
Change default vsan_sdk_path to match perl-VMware-vSphere's install path

### DIFF
--- a/centreon/script/centreon_vmware.pm
+++ b/centreon/script/centreon_vmware.pm
@@ -128,7 +128,7 @@ sub new {
                 #              'username' => 'XXXXX',
                 #              'password' => 'XXXXXX'}
             },
-            vsan_sdk_path => '/usr/share/perl5/VMware',
+            vsan_sdk_path => '/usr/local/share/perl5/VMware',
         );
 
     $self->{return_child} = {};


### PR DESCRIPTION
The RPM provided by Centreon installs its files in
`/usr/local/share/perl5/VMware`.